### PR TITLE
Ruby 1.9 support

### DIFF
--- a/lib/smtp_tls.rb
+++ b/lib/smtp_tls.rb
@@ -31,9 +31,9 @@ Net::SMTP.class_eval do
   def do_tls_start(helodomain, user, secret, authtype)
     raise IOError, 'SMTP session already started' if @started
     
-    if VERSION == '1.8.6'
+    if defined?(VERSION) && VERSION == '1.8.6'
       check_auth_args user, secret, authtype if user or secret
-    elsif VERSION == '1.8.7'
+    else
       check_auth_args user, secret
     end
 


### PR DESCRIPTION
Small change to support Rubies beyond 1.8 familly. 1.9+ ceases to define VERSION and uses RUBY_VERSION instead. 1.8.7 defines both.
